### PR TITLE
squid:S2039 - Member variable visibility should be specified

### DIFF
--- a/app/src/main/java/haibuzou/mvpsample/mvc/MVCActivity.java
+++ b/app/src/main/java/haibuzou/mvpsample/mvc/MVCActivity.java
@@ -61,7 +61,7 @@ public class MVCActivity extends AppCompatActivity{
         });
     }
 
-    AdapterView.OnItemClickListener itemClickListener = new AdapterView.OnItemClickListener() {
+    private AdapterView.OnItemClickListener itemClickListener = new AdapterView.OnItemClickListener() {
         @Override
         public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
             Toast.makeText(MVCActivity.this,"点击了item"+(position+1),Toast.LENGTH_SHORT).show();

--- a/app/src/main/java/haibuzou/mvpsample/mvp/MVPActivity.java
+++ b/app/src/main/java/haibuzou/mvpsample/mvp/MVPActivity.java
@@ -17,9 +17,9 @@ import haibuzou.mvpsample.mvp.view.MvpView;
 
 public class MVPActivity extends AppCompatActivity implements MvpView ,AdapterView.OnItemClickListener{
 
-    ListView mvpListView;
-    MvpPresenter mvpPresenter;
-    ProgressBar pb;
+    private ListView mvpListView;
+    private MvpPresenter mvpPresenter;
+    private ProgressBar pb;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {

--- a/app/src/main/java/haibuzou/mvpsample/mvp/presenter/MvpPresenter.java
+++ b/app/src/main/java/haibuzou/mvpsample/mvp/presenter/MvpPresenter.java
@@ -14,7 +14,7 @@ import haibuzou.mvpsample.mvp.view.MvpView;
 public class MvpPresenter {
 
     private MvpView mvpView;
-    RequestBiz requestBiz;
+    private RequestBiz requestBiz;
     private Handler mHandler;
 
     public MvpPresenter(MvpView mvpView) {

--- a/app/src/main/java/haibuzou/mvpsample/newmvp/NewMvpActivity.java
+++ b/app/src/main/java/haibuzou/mvpsample/newmvp/NewMvpActivity.java
@@ -16,8 +16,8 @@ import haibuzou.mvpsample.basemvp.BaseMvpActivity;
 
 public class NewMvpActivity extends BaseMvpActivity<NewMvpView,NewMvpPresenter> implements NewMvpView,AdapterView.OnItemClickListener{
 
-    ListView mvpListView;
-    ProgressBar pb;
+    private ListView mvpListView;
+    private ProgressBar pb;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2039 - Member variable visibility should be specified

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S2039

Please let me know if you have any questions.

M-Ezzat
